### PR TITLE
Enforce batch size upper bound

### DIFF
--- a/includes/class-assistente-ia-ajax.php
+++ b/includes/class-assistente-ia-ajax.php
@@ -74,7 +74,14 @@ class Assistente_IA_Ajax {
     public function embeddings_step(){
         check_ajax_referer('assistente_ia_nonce','nonce');
         if ( ! current_user_can('manage_options') ) wp_send_json_error(['messaggio'=>'Permessi insufficienti']);
-        $batch = isset($_POST['batch']) ? max(1, (int)$_POST['batch']) : 5;
+        $batch = 5;
+        if ( isset($_POST['batch']) ) {
+            $richiesto = (int) $_POST['batch'];
+            if ( $richiesto > 20 ) {
+                wp_send_json_error(['messaggio' => 'Batch massimo 20']);
+            }
+            $batch = min(20, max(1, $richiesto));
+        }
         $job = Assistente_IA_RAG::esegui_job_passaggio( $batch );
         if ( isset($job['errore']) ) wp_send_json_error( $job );
         wp_send_json_success( $job );


### PR DESCRIPTION
## Summary
- add max batch size check for embeddings job and return error when exceeded

## Testing
- `php -l includes/class-assistente-ia-ajax.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb3c18081483208964572ca4fc1ca1