### PR TITLE
Remove redundant RAG submenu registration

### DIFF
--- a/includes/class-assistente-ia-admin.php
+++ b/includes/class-assistente-ia-admin.php
@@ -39,13 +39,7 @@ public function aggiungi_menu(){
         [ $this, 'pagina_archivio' ]
     );
 
-    // Aggiungi il sottomenu RAG qui SOLO se la classe non lo aggiunge da sola altrove
-    if ( class_exists('Assistente_IA_Admin_RAG') ) {
-        add_submenu_page(
-            'assia', 'RAG (Embeddings)', 'RAG (Embeddings)', 'manage_options', 'assistente-ia-rag',
-            [ 'Assistente_IA_Admin_RAG', 'render_pagina_rag' ]
-        );
-    }
+    // Il sottomenu "RAG (Embeddings)" è registrato dalla classe Assistente_IA_Admin_RAG.
 }
 
 


### PR DESCRIPTION
## Summary
- Remove conditional RAG submenu hook from general admin menu so submenu is only added by dedicated RAG admin class.

## Testing
- `php -l includes/class-assistente-ia-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb3c11d4d8832087935e07be16cff9