### PR TITLE
Use stable identifier for rate limiting

### DIFF
--- a/includes/class-assistente-ia-ajax.php
+++ b/includes/class-assistente-ia-ajax.php
@@ -26,7 +26,7 @@ class Assistente_IA_Ajax {
         $hash=isset($_POST['hash_sessione'])?sanitize_text_field(wp_unslash($_POST['hash_sessione'])):'';
         if(empty($messaggio)||empty($hash)) wp_send_json_error(['messaggio'=>'Richiesta non valida']);
 
-        Assistente_IA_Utilita::limita_richieste_utente($hash);
+        Assistente_IA_Utilita::limita_richieste_utente(get_current_user_id());
 
         $id_chat=$this->ottieni_o_crea_chat($hash);
         $this->salva_messaggio($id_chat,'utente',$messaggio);

--- a/includes/class-assistente-ia-utilita.php
+++ b/includes/class-assistente-ia-utilita.php
@@ -15,13 +15,14 @@ class Assistente_IA_Utilita {
         return $ip ?: '0.0.0.0';
     }
 
-    /** Rate limit per IP+sessione */
-    public static function limita_richieste_utente(string $hash_sessione): void {
+    /** Rate limit per IP e, se disponibile, ID utente autenticato */
+    public static function limita_richieste_utente(int $id_utente = 0): void {
         $max=(int)get_option('assia_rate_limite_max',8);
         $fin=(int)get_option('assia_rate_limite_finestra_sec',60);
         if($max<=0||$fin<=0) return;
         $ip=self::ottieni_indirizzo_ip();
-        $k='assia_rl_'.md5($ip.'|'.$hash_sessione);
+        $id=$ip.'|'.$id_utente;
+        $k='assia_rl_'.md5($id);
         $c=(int)get_transient($k);
         if($c>=$max){ wp_send_json_error(['messaggio'=>'Hai raggiunto il limite di richieste; riprova tra poco.'], 429); }
         set_transient($k,$c+1,$fin);


### PR DESCRIPTION
## Summary
- rate-limit requests by IP and authenticated user ID rather than client-provided session hash
- adjust AJAX handler to supply server-side user ID when enforcing rate limits

## Testing
- `php -l includes/class-assistente-ia-utilita.php`
- `php -l includes/class-assistente-ia-ajax.php`
- `php /tmp/test_rate_limit.php`

------
https://chatgpt.com/codex/tasks/task_e_68bb6bbca40483208bdd50f89a8e2717