### PR TITLE
Rimuovi id utente dal rate limit basato su IP

### DIFF
--- a/includes/class-assistente-ia-ajax.php
+++ b/includes/class-assistente-ia-ajax.php
@@ -26,7 +26,7 @@ class Assistente_IA_Ajax {
         $hash=isset($_POST['hash_sessione'])?sanitize_text_field(wp_unslash($_POST['hash_sessione'])):'';
         if(empty($messaggio)||empty($hash)) wp_send_json_error(['messaggio'=>'Richiesta non valida']);
 
-        Assistente_IA_Utilita::limita_richieste_utente(get_current_user_id());
+        Assistente_IA_Utilita::limita_richieste_utente();
 
         $id_chat=$this->ottieni_o_crea_chat($hash);
         $this->salva_messaggio($id_chat,'utente',$messaggio);

--- a/includes/class-assistente-ia-utilita.php
+++ b/includes/class-assistente-ia-utilita.php
@@ -15,16 +15,15 @@ class Assistente_IA_Utilita {
         return $ip ?: '0.0.0.0';
     }
 
-    /** Rate limit per IP e, se disponibile, ID utente autenticato */
-    public static function limita_richieste_utente(int $id_utente = 0): void {
+    /** Rate limit per IP */
+    public static function limita_richieste_utente(): void {
         $max=(int)get_option('assia_rate_limite_max',8);
         $fin=(int)get_option('assia_rate_limite_finestra_sec',60);
         if($max<=0||$fin<=0){ error_log('Assistente IA: valori rate limit non validi (max='.$max.', fin='.$fin.')'); }
         $max=max(1,$max);
         $fin=max(1,$fin);
         $ip=self::ottieni_indirizzo_ip();
-        $id=$ip.'|'.$id_utente;
-        $k='assia_rl_'.md5($id);
+        $k='assia_rl_'.md5($ip);
         $c=(int)get_transient($k);
         if($c>=$max){ wp_send_json_error(['messaggio'=>'Hai raggiunto il limite di richieste; riprova tra poco.'], 429); }
         set_transient($k,$c+1,$fin);


### PR DESCRIPTION
## Summary
- semplifica `limita_richieste_utente` usando solo l'indirizzo IP per il rate limit
- aggiorna le chiamate alla nuova firma del metodo

## Testing
- `php -l includes/class-assistente-ia-utilita.php`
- `php -l includes/class-assistente-ia-ajax.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb6ff88cb083208e7015ce0ea11eec