### PR TITLE
Valida hash sessione nelle chiamate AJAX

### DIFF
--- a/includes/class-assistente-ia-ajax.php
+++ b/includes/class-assistente-ia-ajax.php
@@ -25,6 +25,9 @@ class Assistente_IA_Ajax {
         $messaggio=isset($_POST['messaggio'])?sanitize_text_field(wp_unslash($_POST['messaggio'])):'';
         $hash=isset($_POST['hash_sessione'])?sanitize_text_field(wp_unslash($_POST['hash_sessione'])):'';
         if(empty($messaggio)||empty($hash)) wp_send_json_error(['messaggio'=>'Richiesta non valida']);
+        if(!Assistente_IA_Utilita::valida_hash_sessione($hash)){
+            wp_send_json_error(['messaggio'=>'Hash sessione non valido']);
+        }
 
         Assistente_IA_Utilita::limita_richieste_utente(get_current_user_id());
 
@@ -51,6 +54,9 @@ class Assistente_IA_Ajax {
         check_ajax_referer('assistente_ia_nonce','nonce');
         $hash=isset($_POST['hash_sessione'])?sanitize_text_field(wp_unslash($_POST['hash_sessione'])):'';
         if(empty($hash)) wp_send_json_error(['messaggio'=>'Hash sessione mancante']);
+        if(!Assistente_IA_Utilita::valida_hash_sessione($hash)){
+            wp_send_json_error(['messaggio'=>'Hash sessione non valido']);
+        }
 
         $id_chat=$this->ottieni_o_crea_chat($hash);
         $m=(int)get_option('assia_messaggi_ui',30);

--- a/includes/class-assistente-ia-utilita.php
+++ b/includes/class-assistente-ia-utilita.php
@@ -42,5 +42,10 @@ class Assistente_IA_Utilita {
         if(strlen($t)<= $n) return $t;
         return substr($t,0,$n-1).'…';
     }
+
+    /** Valida hash sessione esadecimale (64 caratteri) */
+    public static function valida_hash_sessione(string $hash): bool {
+        return (bool) preg_match('/^[a-f0-9]{64}$/i', $hash);
+    }
 }
 


### PR DESCRIPTION
## Summary
- Aggiunta utilità `valida_hash_sessione` per verificare pattern esadecimale a 64 caratteri
- Verifica dell'hash sessione in `gestisci_chat` e `recupera_chat` con errore JSON in caso di formato errato

## Testing
- `php -l includes/class-assistente-ia-utilita.php`
- `php -l includes/class-assistente-ia-ajax.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb6ffa56a08320a26e632e2deef5bd