### PR TITLE
feat: load credentials from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Assistente IA
+
+Plugin WordPress per integrare un assistente basato su Google Vertex AI.
+
+## Credenziali del service account
+
+Le credenziali **non** vengono più salvate nel database. Fornire il JSON del service account in uno dei modi seguenti:
+
+1. **Variabile d'ambiente** `ASSIA_SERVICE_ACCOUNT`
+   - Inserire direttamente il contenuto JSON oppure la versione Base64.
+2. **File esterno** indicato da `ASSIA_SERVICE_ACCOUNT_FILE`
+   - Impostare la variabile d'ambiente con il percorso di un file protetto contenente il JSON o il Base64.
+   - Il file deve trovarsi fuori dal plugin e non deve essere versionato.
+
+Esempio `.env`:
+
+```
+ASSIA_SERVICE_ACCOUNT_FILE=/percorso/privato/credenziali.json
+```
+
+Il plugin leggerà le credenziali all'esecuzione senza archiviarle nel database.
+
+## Configurazione
+
+Le altre impostazioni (Project ID, modelli, ecc.) continuano ad essere gestite tramite la pagina "Assistente IA → Impostazioni" nel pannello di amministrazione di WordPress.
+

--- a/includes/class-assistente-ia-admin.php
+++ b/includes/class-assistente-ia-admin.php
@@ -49,7 +49,7 @@ public function aggiungi_menu(){
 
     public function registra_impostazioni(){
         foreach([
-            'assia_progetto_id','assia_localita','assia_modello','assia_modello_embedding','assia_credenziali_base64',
+            'assia_progetto_id','assia_localita','assia_modello','assia_modello_embedding',
             'assia_obiettivo','assia_avviso','assia_temperature','assia_top_p','assia_top_k','assia_max_token',
             'assia_safety_soglie','assia_attiva_google_search','assia_attiva_embeddings','assia_embeddings_top_k',
             'assia_rag_fallback_threshold', // Aggiunto
@@ -89,10 +89,9 @@ public function aggiungi_menu(){
             <tr><th>Modello</th><td><input name="assia_modello" class="regular-text" value="<?php echo esc_attr(get_option('assia_modello')); ?>"></td></tr>
             <tr><th>Modello Embedding</th><td><input name="assia_modello_embedding" class="regular-text" value="<?php echo esc_attr(get_option('assia_modello_embedding')); ?>"></td></tr>
             <tr>
-                <th>Credenziali (JSON o Base64)</th>
+                <th>Credenziali</th>
                 <td>
-                    <textarea name="assia_credenziali_base64" rows="4" class="large-text" placeholder="Incolla il JSON del service account OPPURE il Base64"><?php echo esc_textarea(get_option('assia_credenziali_base64')); ?></textarea>
-                    <p class="description">Il plugin riconosce automaticamente il formato (JSON in chiaro <strong>o</strong> Base64).</p>
+                    <p class="description">Le credenziali del service account devono essere fornite tramite variabile d'ambiente <code>ASSIA_SERVICE_ACCOUNT</code> (contenente il JSON o Base64) oppure specificando un file nel percorso indicato da <code>ASSIA_SERVICE_ACCOUNT_FILE</code>. Il plugin non salva più le credenziali nel database.</p>
                 </td>
             </tr>
         </table>

--- a/includes/class-assistente-ia-installazione.php
+++ b/includes/class-assistente-ia-installazione.php
@@ -70,7 +70,6 @@ class Assistente_IA_Installazione {
             'assia_localita' => 'us-central1',
             'assia_modello' => 'gemini-2.0-flash-001',
             'assia_modello_embedding' => 'text-embedding-005',
-            'assia_credenziali_base64' => '', // JSON in chiaro O Base64 (auto-rilevato)
             'assia_obiettivo' => 'Sei un assistente utile e preciso.',
             'assia_avviso' => 'Le risposte sono fornite a scopo informativo.',
             'assia_temperature' => 0.2,

--- a/includes/class-assistente-ia-token.php
+++ b/includes/class-assistente-ia-token.php
@@ -7,9 +7,18 @@ if ( ! defined( 'ABSPATH' ) ) { exit; }
  */
 class Assistente_IA_Token {
 
-    /** Legge il JSON del service account (in chiaro o Base64) dalle opzioni */
+    /**
+     * Legge il JSON del service account (in chiaro o Base64) da variabili
+     * d'ambiente o da un file esterno.
+     */
     protected static function leggi_config_service_account(): array {
-        $raw = get_option('assia_credenziali_base64','');
+        $raw = getenv('ASSIA_SERVICE_ACCOUNT');
+        if ( empty($raw) ) {
+            $path = getenv('ASSIA_SERVICE_ACCOUNT_FILE');
+            if ( $path && is_readable($path) ) {
+                $raw = file_get_contents($path);
+            }
+        }
         if ( empty($raw) ) { return []; }
 
         // Se inizia con "{", lo tratto come JSON in chiaro
@@ -77,7 +86,7 @@ class Assistente_IA_Token {
     /** Check veloce credenziali */
     public static function diagnostica_credenziali(): array {
         $cfg=self::leggi_config_service_account();
-        if(empty($cfg)) return ['ok'=>false,'note'=>'Credenziali non presenti o non valide (Base64/JSON).'];
+        if(empty($cfg)) return ['ok'=>false,'note'=>'Credenziali non presenti o non valide (variabili d\'ambiente/file).'];
         $manc=[]; foreach(['type','project_id','client_email','private_key'] as $k){ if(empty($cfg[$k])) $manc[]=$k; }
         if($manc) return ['ok'=>false,'note'=>'Campi mancanti: '.implode(', ',$manc)];
         return ['ok'=>true,'note'=>'Credenziali lette correttamente per '.$cfg['client_email']];


### PR DESCRIPTION
## Summary
- read service account credentials from environment variables or an external file
- stop storing credentials in database and update admin UI accordingly
- document external credential setup

## Testing
- `php -l includes/class-assistente-ia-token.php`
- `php -l includes/class-assistente-ia-admin.php`
- `php -l includes/class-assistente-ia-installazione.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb7f0d0eb8832083a1fd8c20391635