### PR TITLE
Use transient cache for OAuth token

### DIFF
--- a/includes/class-assistente-ia-admin.php
+++ b/includes/class-assistente-ia-admin.php
@@ -413,9 +413,16 @@ public function aggiungi_menu(){
         $cred = Assistente_IA_Token::diagnostica_credenziali();
         $esiti[] = [ 'titolo'=>'Lettura credenziali (JSON/Base64)', 'ok'=>(bool)$cred['ok'], 'messaggio'=>$cred['note'] ];
 
-        $token = Assistente_IA_Token::genera_token_accesso();
+        $token = Assistente_IA_Token::ottieni_token_accesso();
         $ok_token = ! empty($token);
-        $esiti[] = [ 'titolo'=>'Richiesta token OAuth2', 'ok'=>$ok_token, 'messaggio'=> $ok_token ? 'Token ottenuto correttamente.' : 'Errore nel generare il token. Verifica service account (ruolo aiplatform.user) e API Vertex.' ];
+        $info_cache = get_transient('assia_token_gemini');
+        if ( $ok_token && is_array($info_cache) && !empty($info_cache['expires_at']) ) {
+            $ttl = max(0, (int)$info_cache['expires_at'] - time());
+            $msg = 'Token ottenuto correttamente (cache). Scade tra '.$ttl.' secondi.';
+        } else {
+            $msg = $ok_token ? 'Token ottenuto correttamente.' : 'Errore nel generare il token. Verifica service account (ruolo aiplatform.user) e API Vertex.';
+        }
+        $esiti[] = [ 'titolo'=>'Richiesta token OAuth2', 'ok'=>$ok_token, 'messaggio'=> $msg ];
 
         $gen = $ok_token ? Assistente_IA_Modello_Vertex::genera_testo('Scrivi solo: OK') : ['errore'=>'Token mancante'];
         if ( empty($gen['errore']) ) {

--- a/includes/class-assistente-ia-token.php
+++ b/includes/class-assistente-ia-token.php
@@ -35,11 +35,13 @@ class Assistente_IA_Token {
         return $cfg;
     }
 
-    /** Restituisce un token valido (con cache in opzione) */
+    /** Restituisce un token valido (con cache non persistente) */
     public static function ottieni_token_accesso(): string {
-        $s=get_option('assia_token_gemini');
-        if(is_array($s)&&!empty($s['access_token'])&&!empty($s['expires_at'])){
-            if(time() < (int)$s['expires_at']-60){ return $s['access_token']; }
+        $s = get_transient('assia_token_gemini');
+        if (is_array($s) && !empty($s['access_token']) && !empty($s['expires_at'])) {
+            if (time() < (int) $s['expires_at'] - 60) {
+                return $s['access_token'];
+            }
         }
         return self::genera_token_accesso();
     }
@@ -70,7 +72,7 @@ class Assistente_IA_Token {
         $body=json_decode(wp_remote_retrieve_body($res),true);
         if(200!==$code||empty($body['access_token'])) return '';
         $token=$body['access_token']; $exp=$now+(int)($body['expires_in']??3600);
-        update_option('assia_token_gemini',['access_token'=>$token,'expires_at'=>$exp]);
+        set_transient('assia_token_gemini',[ 'access_token'=>$token, 'expires_at'=>$exp ], max(1,$exp-$now));
         return $token;
     }
 


### PR DESCRIPTION
## Summary
- cache OAuth token with `set_transient` and auto-refresh on expiry
- update diagnostics to report transient token status

## Testing
- `php -l includes/class-assistente-ia-token.php`
- `php -l includes/class-assistente-ia-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb7f0efb588320a16e49aa56be0119